### PR TITLE
Configure Host and Port

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -34,7 +34,7 @@
             console.log("input", JSON.stringify({
                 mode: mode,
             }));
-            var response = await fetch('http://localhost:8080/new_game', {
+            var response = await fetch('/new_game', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -53,7 +53,7 @@
                 if (mode === 'playerVsBot') {
                     window.location.href = `/${game_id}`;
                 } else if (mode === 'botVsBot') {
-                    console.log(`http://localhost:8080/spectate/${game_id}`);
+                    console.log(`/spectate/${game_id}`);
                     window.location.href = `/spectate/${game_id}`;
                 }
             } else {

--- a/client/player_vs_bot.html
+++ b/client/player_vs_bot.html
@@ -72,7 +72,7 @@
         // Move Piece, update board, and set playerTurn to false
         async function movePiece(move) {
            playerTurn = false; 
-           var response = await fetch('http://localhost:8080/new_game', {
+           var response = await fetch('/new_game', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/client/spectate.html
+++ b/client/spectate.html
@@ -36,7 +36,7 @@
         board = Chessboard('board1', config);
 
         // WebSocket initialization
-        var socket = new WebSocket('ws://127.0.0.1:8080/ws/');
+        var socket = new WebSocket(`ws://${window.location.host}/ws/`);
 
         socket.onopen = function(event) {
             console.log("WebSocket connection established");

--- a/readme.md
+++ b/readme.md
@@ -12,4 +12,6 @@ cargo run
 This should automatically open your webbrowser to `localhost:8080`. 
 
 # Adjusting Hostname and Port
-Currently the client side code is hardcoded to point at localhost:8080, so nothing else will work :/
+```
+cargo run -- --port <port> --hostname <host>
+```


### PR DESCRIPTION
# Description
Using relative urls in the client will automatically make requests to the server which returned the client (thanks chat gpt). By making it relative, the port and host can now be configured using the existing cli tool.

# Test
I just ran
```
cargo run -- p 2424
```