### PR TITLE
allow no port if port 80

### DIFF
--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -193,12 +193,16 @@ pub async fn start_server(hostname: String, port: u16) -> std::io::Result<()> {
     println!("Starting server on {}:{}", hostname, port);
     let allowed_origin = format!("http://{}:{}", &hostname, &port);
     HttpServer::new(move || {
-        let cors = Cors::default()
+        let mut cors = Cors::default()
             .allowed_origin(&allowed_origin)
             .allowed_methods(vec!["GET", "POST", "PUT", "DELETE", "OPTIONS"])
             .allowed_headers(vec![http::header::AUTHORIZATION, http::header::ACCEPT])
             .allowed_header(http::header::CONTENT_TYPE)
             .max_age(3600);
+
+        if port == 80 {
+            cors = cors.allowed_origin(&format!("http://{hostname}"))
+        }
 
         // because we are doing a wildcard match with render game, the order of the
         // routes actually does matter here


### PR DESCRIPTION
# Description
When serving this on port 80 so that I could access this with no port in browser I was blocked by CORS. This made it work for me but this feels like there should be a better way to do this but idk much about cors.

# Test
Ran on http://rustiator.ferris.place
Something is up with websockets on my remote setup I think but cors does not block it