### PR TITLE
small bug fixes

### DIFF
--- a/client/game.html
+++ b/client/game.html
@@ -52,6 +52,9 @@
           oldPosition,
           currentOrientation
         ) {
+            if (draggedPieceSource === draggedPieceDest) {
+                return;
+            }
             // This is most definitely incomplete
             var uci = draggedPieceSource + draggedPieceDest;
 
@@ -83,6 +86,7 @@
                 return state;
             } else {
                 console.error('Error Sending Request:', response.statusText);
+                console.error('Full Response', response);
             }
         }
 

--- a/src/player_vs_bot.rs
+++ b/src/player_vs_bot.rs
@@ -46,8 +46,7 @@ impl PlayerGame {
                     // guarantee that there are legal moves 
                     if legal_moves.is_empty() {
                         let msg = format!(
-                            "Despite the game not being over, the bot returned None for a move. 
-                            Game FEN {}. There are no legal moves",
+                            "Despite the game not being over There are no legal moves. FEN {}",
                             self.game.fen()
                         );
                         error!("{}", msg);

--- a/src/player_vs_bot.rs
+++ b/src/player_vs_bot.rs
@@ -1,4 +1,6 @@
+use log::{info, error};
 use shakmaty::Move;
+use anyhow::Result;
 
 use crate::{chess_engine::ChooseMove, chess_game::ChessGame};
 
@@ -16,17 +18,49 @@ impl PlayerGame {
     }
 
     /// Takes in player move and then playes the bot move that responds to this. Also returns the move
-    pub fn play_move(&mut self, player_move: Move) -> Move {
+    pub fn play_move(&mut self, player_move: Move) -> Result<Option<Move>> {
         self.game.make_move(&player_move);
+
+        let legal_moves = &self.game.get_legal_moves();
+
+        // legal moves should be a stronger condition
+        // than game over, there are scenario (like the 50 move rule)
+        // where the game is over but there are still legal moves
+        if self.game.game_over() {
+            return Ok(None);
+        }
+
         // FIXME: remove unwrap. What does `None` mean for a choose move? it ran out of time?
-        let bot_move = self
+        let bot_move = match self
             .bot
-            .choose_move(&self.game.fen(), &self.game.get_legal_moves())
-            .unwrap();
+            .choose_move(&self.game.fen(), &legal_moves) {
+                Some(m) => m,
+                None => {
+                    // not really sure what we are supposed to do here
+                    // this is not a mistake by the player its a mistake by the bot
+                    error!("Despite the game not being over, 
+                        the bot returned None for a move. Game FEN {}.
+                        Defaulting to a random move", self.game.fen());
+
+                    // as mentioned above, the game not being over should
+                    // guarantee that there are legal moves 
+                    if legal_moves.is_empty() {
+                        let msg = format!(
+                            "Despite the game not being over, the bot returned None for a move. 
+                            Game FEN {}. There are no legal moves",
+                            self.game.fen()
+                        );
+                        error!("{}", msg);
+                        return Err(anyhow::anyhow!(msg));
+                    }
+
+                    legal_moves[0].clone()
+                }
+            };
 
         self.game.make_move(&bot_move);
 
-        bot_move
+        Ok(Some(bot_move))
     }
 
     pub fn fen(&self) -> String {


### PR DESCRIPTION
# Description
Couple of small changes to the original playerVsBot branch
* Was noticing that the game assets were not caching in my browser (so I explicitly set that with a middleware)
* Don't send to the backend if the player tries to move back to the same square again
* Consolidate game ending logic for player vs bot and bot vs bot
* add some error handling to the player vs bot function

# Testing
* Ran a full player vs bot game to completion with no network errors or unncessary reloading of assets
* Ran bot vs bot to verify the migration of logic did not break anything